### PR TITLE
Support for privateKeyFile option as a Buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,11 @@ var SFTPServer=require('node-sftp-server');
 ### constructor
 
 ```js
-var myserver = new SFTPServer({ privateKeyFile: "path_to_private_key_file" });
+var myServerFromPrivateKeyPath = new SFTPServer({ privateKeyFile: "path_to_private_key_file" });
+
+// Alternatively (when Buffer.isBuffer(options.privateKeyFile) is true, node-sftp-server knows to use that as the host key)
+var myServerFromPrivateKeyBuffer = new SFTPServer({ privateKeyFile: fs.readFileSync("path_to_private_key_file") });
+
 ```
 
 This returns a new `SFTPServer()` object, which is an EventEmitter. If the private

--- a/node-sftp-server.js
+++ b/node-sftp-server.js
@@ -131,10 +131,22 @@ var SFTPServer = (function(superClass) {
     if (options.debug) {
       debug = function(msg) { console.log(msg); };
     }
+    // Treat Buffer
+    let hostKeys = [];
+    if (typeof options.privateKeyFile === 'string') {
+      hostKeys.push(fs.readFileSync(options.privateKeyFile));
+    }
+    else if (Buffer.isBuffer(options.privateKeyFile)) {
+      hostKeys.push(options.privateKeyFile);
+    }
+    let serverOptions = {
+      hostKeys
+    }
+    if(options.algorithms){
+      serverOptions.algorithms = options.algorithms;
+    }
     SFTPServer.options = options;
-    this.server = new ssh2.Server({
-      hostKeys: [fs.readFileSync(options.privateKeyFile)]
-    }, (function(_this) {
+    this.server = new ssh2.Server(serverOptions, (function(_this) {
       return function(client, info) {
         client.on('error', function(err) {
           debug("SFTP Server: error");


### PR DESCRIPTION
This will allow the privateKeys to be loaded before the SFTP server is instantiated, then passed as a Buffer in the options in the constructor. For example, when the keys are to be pulled from secure online storage instead of kept on disk.